### PR TITLE
Add TypeScript declaration file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'graphql-disable-introspection' {
+  import type { ValidationRule } from 'graphql';
+
+  const NoIntrospection: ValidationRule;
+
+  export = NoIntrospection;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "Disable introspection in graphql-js with a validation rule",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "doc": "docs",
     "test": "tests"


### PR DESCRIPTION
Solves issue #3.

Adds a TypeScript declaration file which allows this library to be utilized in TypeScript projects.

Pretty simple, it just re-exports the correct type from `graphql`.